### PR TITLE
Fix compilation errors

### DIFF
--- a/classify_fake_DS18B20.ino
+++ b/classify_fake_DS18B20.ino
@@ -308,8 +308,8 @@ void loop() {
     int identified = 0;
 
     { // test for family E, added 19 March 2024
-      uint8_t sp21, sp22;
-      uint8_t sp21b, sp22b;
+      uint32_t sp21, sp22;
+      uint32_t sp21b, sp22b;
       ds->reset();
       ds->select(addr);
       ds->write(0xDE);

--- a/discover_fake_DS18B20.ino
+++ b/discover_fake_DS18B20.ino
@@ -91,7 +91,7 @@ void setup() {
   
   {
     // output file name without leading path
-    char *file = __FILE__;
+    auto *file = __FILE__;
     int i;
     for (i = strlen(file); i > 0; i--)
       if ((file[i] == '\\') || (file[i] == '/')) {
@@ -273,8 +273,7 @@ void loop() {
 
     Comm.print("  Checking byte 6 upon temperature change: ");
     if (( ((buffer2[0] == 0x50) && (buffer2[1] == 0x05)) || ((buffer2[0] == 0xff) && (buffer2[1] == 0x07)) ||
-         ((buffer2[6] == 0x0c) && (((buffer2[0] + buffer2[6]) & 0x0f) == 0x00)) ) &&
-         ((buffer2[6] >= 0x00) && (buffer2[6] <= 0x10)) ){
+         ((buffer2[6] == 0x0c) && (((buffer2[0] + buffer2[6]) & 0x0f) == 0x00)) ) && (buffer2[6] <= 0x10) ){
       // byte 6 checked out as correct in the initial test but the test ambiguous.
       //   we need to check if byte 6 is consistent after temperature conversion
             


### PR DESCRIPTION
Fixes the following compilation errors:

discover_fake_DS18B20.ino: In function 'void setup()': discover_fake_DS18B20.ino:94:18: error: ISO C++ forbids
  converting a string constant to 'char*' [-Werror=write-strings]
   94 |     char *file = __FILE__;
      |                  ^~~~~~~~
discover_fake_DS18B20.ino: In function 'void loop()':
discover_fake_DS18B20.ino:277:23: error: comparison is always true
  due to limited range of data type [-Werror=type-limits]
  277 |          ((buffer2[6] >= 0x00) && (buffer2[6] <= 0x10)) ){
      |            ~~~~~~~~~~~^~~~~~~

classify_fake_DS18B20.ino:328:38: error: comparison of promoted
  bitwise complement of an unsigned value with unsigned
    [-Werror=sign-compare]
  328 |       if ((sp21b == ~sp21) && (sp22b == ~sp22)) {
      |            ~~~~~~^~~~~~~~
  328 |       if ((sp21b == ~sp21) && (sp22b == ~sp22)) {
      |                                ~~~~~~^~~~~~~~